### PR TITLE
Update build workflow to build multi-architecture (amd64 + arm64) images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -84,6 +84,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
This updates the build and push workflow to produce a multi-architecture image that supports both amd64 and arm64. The functionality was prepared during the setup buildx task, however wasn't being used during the actual build. This resolves it.