### PR TITLE
feat(ci): tag images with commit hash

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,7 +21,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     permissions:
       contents: read
       packages: write
@@ -66,6 +66,10 @@ jobs:
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=long
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
Fixes #4.

Commits to `master` will cause images to be tagged `master` (replacing previous digest) as before, but with this PR merged they'll also get a `sha-*` tag based on commit hash. This will provide mostly immutable images, assuming the `sha-*` tag isn't replaced with another digest later, of course.

https://github.com/docker/metadata-action/tree/v5.0.0?tab=readme-ov-file#typesha

Here's how it looks on a test repo:

<img width="407" height="297" alt="obraz" src="https://github.com/user-attachments/assets/9610093f-5dba-46f6-8760-b70cb972cfba" />
